### PR TITLE
Migrate Maven Central publishing to the Central Portal (OSSRH EOL)

### DIFF
--- a/status-machina-core/build.gradle.kts
+++ b/status-machina-core/build.gradle.kts
@@ -86,8 +86,13 @@ publishing {
     repositories {
         maven {
             name = "MavenCentral"
-            val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            // OSSRH (oss.sonatype.org) reached end of life on 2025-06-30. Releases now go through the
+            // Central Portal's OSSRH-compatibility staging API; snapshots use the Portal snapshot repo.
+            // After CI uploads, the deployment appears at https://central.sonatype.com/publishing/deployments
+            // to be validated and published. Credentials must be a Central Portal user token
+            // (generate at https://central.sonatype.com/usertoken) — old OSSRH credentials no longer work.
+            val releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+            val snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
             url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
             credentials {
                 username = MAVEN_UPLOAD_USER

--- a/status-machina-spring/build.gradle.kts
+++ b/status-machina-spring/build.gradle.kts
@@ -106,8 +106,13 @@ publishing {
     repositories {
         maven {
             name = "MavenCentral"
-            val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            // OSSRH (oss.sonatype.org) reached end of life on 2025-06-30. Releases now go through the
+            // Central Portal's OSSRH-compatibility staging API; snapshots use the Portal snapshot repo.
+            // After CI uploads, the deployment appears at https://central.sonatype.com/publishing/deployments
+            // to be validated and published. Credentials must be a Central Portal user token
+            // (generate at https://central.sonatype.com/usertoken) — old OSSRH credentials no longer work.
+            val releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+            val snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
             url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
             credentials {
                 username = MAVEN_UPLOAD_USER


### PR DESCRIPTION
## Why

The `9.0.0` release build fails at the publish step with:

```
Could not PUT '.../oss.sonatype.org/.../status-machina-core-9.0.0.pom'.
Received status code 402 from server: Payment Required
```

This is **not** a GitHub Actions charge and Maven Central is still free for open source. The cause is that **OSSRH (`oss.sonatype.org`) reached end of life on 2025-06-30** and was shut down; that legacy host now returns `402` instead of accepting deployments. Free OSS publishing moved to the **Central Portal**. The build and tests themselves pass — only the upload fails.

## What this changes

Repoints the `MavenCentral` publishing repository in **both modules** from the dead OSSRH host to the Central Portal's **OSSRH-compatibility staging API** — a near drop-in for the old Nexus 2 staging deploy endpoint, so the existing `maven-publish` + `signing` setup is otherwise untouched:

| | before | after |
|---|---|---|
| releases | `https://oss.sonatype.org/service/local/staging/deploy/maven2` | `https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/` |
| snapshots | `https://oss.sonatype.org/content/repositories/snapshots` | `https://central.sonatype.com/repository/maven-snapshots/` |

No changes to the credentials wiring, signing, sources/javadoc jars, or POM. `./gradlew publish...MavenCentralRepository --dry-run` configures cleanly.

## ⚠️ Maintainer action required (cannot be done in this PR)

These need your Central Portal account and can't be tested from a fork:

1. **Verify the `io.statusmachina` namespace** in the Central Portal (log in at https://central.sonatype.com with your old OSSRH account — namespaces were migrated automatically).
2. **Generate a Central Portal user token** at https://central.sonatype.com/usertoken and update the repo secrets `SONATYPE_USER` / `SONATYPE_PASSWORD` (which feed `MAVEN_UPLOAD_USER` / `MAVEN_UPLOAD_PWD`) with it. **Old OSSRH credentials no longer work.**
3. After a build uploads, go to https://central.sonatype.com/publishing/deployments to validate and **publish** the deployment (same manual close/release step as the old OSSRH staging UI).

## Notes / alternatives

- The OSSRH-compat shim has known limitations (staging repos are per-user and IP-isolated). For most single-account CI publishing this is fine.
- If you'd prefer a fuller, longer-term migration instead of the shim, a common choice for Gradle is the `com.vanniktech.maven.publish` plugin (talks to the Portal API directly, with `autoPublish`/`waitUntil` options). Happy to provide that variant if you'd rather go that route.

Refs: [OSSRH sunset](https://central.sonatype.org/pages/ossrh-eol/) · [OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/)