### PR TITLE
Auto-release to Maven Central in CI (remove the manual publish step)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,6 +18,26 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
         run: ./gradlew -PMAVEN_UPLOAD_USER=${{ secrets.SONATYPE_USER }} -PMAVEN_UPLOAD_PWD=${{ secrets.SONATYPE_PASSWORD }}  -PPGP_SIGNING_KEY="${{ secrets.PGP_SIGNING_KEY }}" -PPGP_SIGNING_PASSWORD="${{ secrets.PGP_SIGNING_PASSWORD }}" build publish
+      # The previous step uploads the artifacts into an OPEN staging repository on the Central Portal's
+      # OSSRH-compatibility API, but a raw maven-publish PUT never finalizes it — so without this step the
+      # release just sits in an invisible open repo and never reaches Maven Central. This finalizes the
+      # namespace's staging repo with publishing_type=automatic, which validates AND releases it with no
+      # manual click. Only runs for release (non-SNAPSHOT) versions; snapshots use the snapshot repo.
+      - name: Release staged deployment to Maven Central
+        env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        run: |
+          version=$(grep -E '^version=' gradle.properties | cut -d= -f2)
+          if [[ "$version" == *SNAPSHOT ]]; then
+            echo "Version $version is a snapshot — nothing to finalize."
+            exit 0
+          fi
+          bearer=$(printf '%s' "$SONATYPE_USER:$SONATYPE_PASSWORD" | base64 -w0)
+          echo "Finalizing and auto-publishing the io.statusmachina staging repository for $version..."
+          curl --fail-with-body -sS -X POST \
+            -H "Authorization: Bearer $bearer" \
+            "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io.statusmachina?publishing_type=automatic"
 
   # Forward-compatibility check: the library is built against the springBootVersion baseline in
   # gradle.properties, but Spring guarantees backward compatibility within a major version. This job


### PR DESCRIPTION
## Problem

`9.0.0` built green and the artifacts uploaded — but the release never reached Maven Central and **no deployment shows up** in the Central Portal. Root cause: the OSSRH-compatibility shim only *stages* an upload. A raw `maven-publish` `PUT` lands the files in an **open staging repository** but never finalizes (closes) it — the old `oss.sonatype.org` flow relied on a Nexus staging plugin to do that, which this build doesn't have. So the release sits in an invisible open repo and never publishes.

## Fix

Add one CI step after `build publish` that finalizes the namespace's staging repository through the [OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) with `publishing_type=automatic`, which validates **and** releases to Maven Central with **no manual click**:

```yaml
- name: Release staged deployment to Maven Central
  env:
    SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
    SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
  run: |
    version=$(grep -E '^version=' gradle.properties | cut -d= -f2)
    if [[ "$version" == *SNAPSHOT ]]; then echo "snapshot — nothing to finalize"; exit 0; fi
    bearer=$(printf '%s' "$SONATYPE_USER:$SONATYPE_PASSWORD" | base64 -w0)
    curl --fail-with-body -sS -X POST \
      -H "Authorization: Bearer $bearer" \
      "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io.statusmachina?publishing_type=automatic"
```

- Reuses the existing `SONATYPE_USER` / `SONATYPE_PASSWORD` secrets (your Central Portal user token) — **no new secrets, no build-script changes**.
- Only runs for release versions; snapshots are skipped.
- `--fail-with-body` surfaces any Portal validation error in the log instead of silently passing.

## Effect

Merging this triggers a build on `master` that should publish `9.0.0` to Maven Central end to end, and every future release publishes automatically.

## Notes

- This keeps the OSSRH-compat shim (smallest, lowest-risk change, built on the publish path that already succeeded). A fuller alternative is migrating to the `com.vanniktech.maven.publish` Gradle plugin with `automaticRelease` — happy to provide that instead if you'd prefer to drop the shim entirely.
- Out of scope but worth flagging: the workflow runs `publish` on **every push to `master`**, so it re-attempts a release each time. Maven Central versions are immutable, so a push that doesn't bump the version will fail at release. Gating publishing to tags (`on: push: tags:`) or a manual `workflow_dispatch` would be a cleaner long-term trigger — let me know if you want a follow-up for that.